### PR TITLE
Add Xcode-formatted GPX exporting

### DIFF
--- a/GeoTrackKit/Core/Extension/DateExtension.swift
+++ b/GeoTrackKit/Core/Extension/DateExtension.swift
@@ -10,6 +10,24 @@ import Foundation
 
 public extension Date {
 
+    /// Gives you the MSSE (Milliseconds Since the Epoch) representation of this date
+    var msse: Double {
+        return timeIntervalSince1970 * 1000
+    }
+
+    /// Converts this date to an iso8601 string.
+    ///
+    /// The format looks something like this:
+    /// ```text
+    /// 2019-01-06T13:00:51Z
+    /// ```
+    var iso8601Date: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+
+        return formatter.string(from: self)
+    }
+
     /// Gets you a Date from the provided MSSE (Milliseconds Since the Epoch)
     ///
     /// - Parameter msse: the number of milliseconds since the epoch (as a double)
@@ -18,10 +36,4 @@ public extension Date {
         let timeInterval = TimeInterval(msse / 1000)
         return Date(timeIntervalSince1970: timeInterval)
     }
-
-    /// Gives you the MSSE (Milliseconds Since the Epoch) representation of this date
-    var msse: Double {
-        return timeIntervalSince1970 * 1000
-    }
-
 }

--- a/GeoTrackKit/Core/Models/GeoTrack.swift
+++ b/GeoTrackKit/Core/Models/GeoTrack.swift
@@ -91,7 +91,7 @@ public extension GeoTrack {
 
 public extension GeoTrack {
 
-    /// Converts this track into an Xcode satisfying GPX
+    /// Creates a string that is a GPX file that Xcode can use for simulating location
     var xcodeGpx: String {
         var result = """
 <?xml version="1.0"?>

--- a/GeoTrackKit/Core/Models/GeoTrack.swift
+++ b/GeoTrackKit/Core/Models/GeoTrack.swift
@@ -87,6 +87,30 @@ public extension GeoTrack {
 
 }
 
+// MARK: - GPX API
+
+public extension GeoTrack {
+
+    /// Converts this track into an Xcode satisfying GPX
+    var xcodeGpx: String {
+        var result = """
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Xcode">
+
+"""
+        for point in points {
+            result += """
+            <wpt lat="\(point.coordinate.latitude)" lon="\(point.coordinate.longitude)"><ele>\(point.altitude)</ele><time>\(point.timestamp.iso8601Date)</time></wpt>\n
+            """
+        }
+
+        result += "\n</gpx>"
+
+        return result
+    }
+
+}
+
 // MARK: - API(Events)
 
 public extension GeoTrack {

--- a/GeoTrackKitExample/GeoTrackKitExample/Base.lproj/Main.storyboard
+++ b/GeoTrackKitExample/GeoTrackKitExample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="xmy-us-EB5">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="xmy-us-EB5">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,7 +21,7 @@
                     <connections>
                         <segue destination="tBK-oR-W6E" kind="relationship" relationship="viewControllers" id="0g8-hp-Ff4"/>
                         <segue destination="OVK-Q8-tUv" kind="relationship" relationship="viewControllers" id="H0b-r1-kbD"/>
-                        <segue destination="OaI-S6-tDf" kind="relationship" relationship="viewControllers" id="dcO-FC-dRU"/>
+                        <segue destination="wj6-hs-RS0" kind="relationship" relationship="viewControllers" id="dcO-FC-dRU"/>
                         <segue destination="j5O-Cr-Gkr" kind="relationship" relationship="viewControllers" id="Gxm-EH-npj"/>
                     </connections>
                 </tabBarController>
@@ -33,11 +33,11 @@
         <scene sceneID="9hM-Gc-zrp">
             <objects>
                 <viewControllerPlaceholder storyboardName="TrackView" referencedIdentifier="TrackMapViewController" id="OaI-S6-tDf" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="" image="map-location" id="u9j-ex-vh6"/>
+                    <navigationItem key="navigationItem" id="TEC-mo-HjF"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="K2p-gH-Vvj" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-197" y="-1332"/>
+            <point key="canvasLocation" x="829" y="-1332"/>
         </scene>
         <!--TrackImport-->
         <scene sceneID="9lZ-bp-zgW">
@@ -69,6 +69,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8CA-54-B4d" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-249" y="-1509"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="4JH-aI-Bs0">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="wj6-hs-RS0" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="" image="map-location" id="u9j-ex-vh6"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fTy-0J-Thn">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="OaI-S6-tDf" kind="relationship" relationship="rootViewController" id="y4z-OX-z4D"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="eF2-9K-mMH" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="215" y="-1332"/>
         </scene>
     </scenes>
     <resources>

--- a/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackMapViewController.swift
+++ b/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackMapViewController.swift
@@ -43,15 +43,59 @@ class TrackMapViewController: UIViewController {
         modelUpdated()
     }
 
-    @IBAction
-    func tappedShare(_ source: Any) {
-        guard let trackWrittenToJsonFile = trackWrittenToJsonFile else {
-            return
-        }
-        let activityVC = UIActivityViewController(activityItems: [trackWrittenToJsonFile], applicationActivities: nil)
-        present(activityVC, animated: true, completion: nil)
+    /// Loads this view from a storyboard.
+    ///
+    /// - Returns: A new TrackMapViewController.
+    class func loadFromStoryboard(useDemoTrack: Bool = false) -> TrackMapViewController {
+        // swiftlint:disable:next force_cast
+        let trackVC = UIStoryboard(name: "TrackView", bundle: nil).instantiateViewController(withIdentifier: "TrackMapViewController") as! TrackMapViewController
+        trackVC.useDemoTrack = useDemoTrack
+        return trackVC
     }
 
+}
+
+// MARK: - User Actions
+
+extension TrackMapViewController {
+
+    @IBAction
+    func tappedShare(_ source: Any) {
+        showShareOptions()
+    }
+
+}
+
+// MARK: - Listeners
+
+extension TrackMapViewController {
+
+    @objc
+    func legVisiblityChanged(_ notification: NSNotification) {
+        mapView.renderTrack()
+    }
+
+}
+
+// MARK: - Navigation
+
+extension TrackMapViewController {
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let destinationVC = segue.destination as? TrackOverviewTableViewController else {
+            return
+        }
+        tableVC = destinationVC
+        tableVC?.model = model
+    }
+
+}
+
+// MARK: - Implementation
+
+private extension TrackMapViewController {
+
+    /// Writes the track to a JSON file and gives you back the URL
     var trackWrittenToJsonFile: URL? {
         guard let model = model else {
             return nil
@@ -82,16 +126,119 @@ class TrackMapViewController: UIViewController {
         return nil
     }
 
-    /// Loads this view from a storyboard.
-    ///
-    /// - Returns: A new TrackMapViewController.
-    class func loadFromStoryboard(useDemoTrack: Bool = false) -> TrackMapViewController {
-        // swiftlint:disable:next force_cast
-        let trackVC = UIStoryboard(name: "TrackView", bundle: nil).instantiateViewController(withIdentifier: "TrackMapViewController") as! TrackMapViewController
-        trackVC.useDemoTrack = useDemoTrack
-        return trackVC
+    /// Writes the track to a GPX file and gives you back the URL
+    var trackWrittenToGpxFile: URL? {
+        guard let model = model else {
+            return nil
+        }
+
+        do {
+            let documentsFolder = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+            let fileName = model.track.name.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ":", with: "_")
+            let fileUrl = documentsFolder.appendingPathComponent("\(fileName).gpx")
+
+            guard let gpxString = gpxString, let data = gpxString.data(using: .utf8) else {
+                return nil
+            }
+
+            do {
+                try data.write(to: fileUrl, options: [])
+            } catch {
+                print(error)
+                assertionFailure(error.localizedDescription)
+                return nil
+            }
+            return fileUrl
+        } catch {
+            print("ERROR trying to serialize to JSON: \(error.localizedDescription)")
+            print("\(error)")
+            assertionFailure(error.localizedDescription)
+        }
+
+        return nil
     }
 
+    /// A String that contains the GPX File.
+    var gpxString: String? {
+        guard let model = model else {
+            return nil
+        }
+
+        var result = """
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Xcode">
+
+"""
+
+        for point in model.track.points {
+            result += """
+<wpt lat="\(point.coordinate.latitude)" lon="\(point.coordinate.longitude)"><ele>\(point.altitude)</ele><time>\(point.timestamp.iso8601Date)</time></wpt>\n
+"""
+        }
+
+        result += "\n</gpx>"
+
+        return result
+    }
+
+    /// Shows a action sheet with a set of sharing options.
+    func showShareOptions() {
+        let dialog = UIAlertController(title: "Share", message: "How would you like to share?", preferredStyle: .actionSheet)
+
+        dialog.addAction(UIAlertAction(title: "JSON", style: .default) { [weak self] _ in
+            self?.shareJsonFile()
+            dialog.dismiss(animated: true)
+        })
+        dialog.addAction(UIAlertAction(title: "GPX", style: .default) { [weak self] _ in
+            self?.shareGPX()
+            dialog.dismiss(animated: true)
+        })
+        dialog.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        present(dialog, animated: true)
+    }
+
+    /// Shares the track as a GPX file
+    func shareGPX() {
+        guard let trackWrittenToGpxFile = trackWrittenToGpxFile else {
+            return
+        }
+        let activityVC = UIActivityViewController(activityItems: [trackWrittenToGpxFile], applicationActivities: nil)
+        present(activityVC, animated: true, completion: nil)
+    }
+
+    /// Shares the track as a JSON file
+    func shareJsonFile() {
+        guard let trackWrittenToJsonFile = trackWrittenToJsonFile else {
+            return
+        }
+        let activityVC = UIActivityViewController(activityItems: [trackWrittenToJsonFile], applicationActivities: nil)
+        present(activityVC, animated: true, completion: nil)
+    }
+
+    /// Updates the view when the model is updated
+    func modelUpdated() {
+        assert(Thread.isMainThread)
+
+        model?.toggleAll(visibility: legVisibleByDefault)
+        guard mapView != nil else {
+            return
+        }
+        mapView.model = model
+        tableVC?.model = model
+
+        if !useDemoTrack {
+            title = model?.track.name
+        }
+    }
+
+    /// Attempts to load the provided file / type from the Bundle that this VC is in,
+    /// deserialize it into a GeoTrack and return it to you.
+    ///
+    /// - Parameters:
+    ///   - filename: the name of the file
+    ///   - type: the type of the file (extension)
+    /// - Returns: A GeoTrack if it could be read / deserialized without issue.
     static func loadFromBundle(filename: String, type: String) -> GeoTrack? {
         guard let path = Bundle(for: TrackMapViewController.self).path(forResource: filename, ofType: type) else {
             assertionFailure("Couldn't load file: \(filename).\(type)")
@@ -112,41 +259,16 @@ class TrackMapViewController: UIViewController {
         return track
     }
 
-    private func modelUpdated() {
-        model?.toggleAll(visibility: legVisibleByDefault)
-        guard mapView != nil else {
-            return
-        }
-        mapView.model = model
-        tableVC?.model = model
-
-        if !useDemoTrack {
-            title = model?.track.name
-        }
-    }
 }
 
-// MARK: - Listeners
+extension Date {
 
-extension TrackMapViewController {
+    /// Converts this date to an iso8601 string.
+    var iso8601Date: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 
-    @objc
-    func legVisiblityChanged(_ notification: NSNotification) {
-        mapView.renderTrack()
-    }
-
-}
-
-// MARK: - Navigation
-
-extension TrackMapViewController {
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        guard let destinationVC = segue.destination as? TrackOverviewTableViewController else {
-            return
-        }
-        tableVC = destinationVC
-        tableVC?.model = model
+        return formatter.string(from: self)
     }
 
 }

--- a/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackMapViewController.swift
+++ b/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackMapViewController.swift
@@ -137,7 +137,8 @@ private extension TrackMapViewController {
             let fileName = model.track.name.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ":", with: "_")
             let fileUrl = documentsFolder.appendingPathComponent("\(fileName).gpx")
 
-            guard let gpxString = gpxString, let data = gpxString.data(using: .utf8) else {
+            let gpxString = model.track.xcodeGpx
+            guard let data = gpxString.data(using: .utf8) else {
                 return nil
             }
 
@@ -156,29 +157,6 @@ private extension TrackMapViewController {
         }
 
         return nil
-    }
-
-    /// A String that contains the GPX File.
-    var gpxString: String? {
-        guard let model = model else {
-            return nil
-        }
-
-        var result = """
-<?xml version="1.0"?>
-<gpx version="1.1" creator="Xcode">
-
-"""
-
-        for point in model.track.points {
-            result += """
-<wpt lat="\(point.coordinate.latitude)" lon="\(point.coordinate.longitude)"><ele>\(point.altitude)</ele><time>\(point.timestamp.iso8601Date)</time></wpt>\n
-"""
-        }
-
-        result += "\n</gpx>"
-
-        return result
     }
 
     /// Shows a action sheet with a set of sharing options.
@@ -257,18 +235,6 @@ private extension TrackMapViewController {
         let track = GeoTrack(json: jsonMap)
 
         return track
-    }
-
-}
-
-extension Date {
-
-    /// Converts this date to an iso8601 string.
-    var iso8601Date: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-
-        return formatter.string(from: self)
     }
 
 }

--- a/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackView.storyboard
+++ b/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackView.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cse-if-UgT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cse-if-UgT">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,13 +19,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="hybrid" translatesAutoresizingMaskIntoConstraints="NO" id="egO-IS-oa8" customClass="GeoTrackMap" customModule="GeoTrackKit">
-                                <rect key="frame" x="0.0" y="8" width="375" height="400"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="400"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="400" id="JIZ-6W-ZA3"/>
                                 </constraints>
                             </mapView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j3W-b1-aMI">
-                                <rect key="frame" x="0.0" y="408" width="375" height="195"/>
+                                <rect key="frame" x="0.0" y="400" width="375" height="203"/>
                                 <connections>
                                     <segue destination="Kom-qy-mum" kind="embed" id="c3y-gj-OWQ"/>
                                 </connections>
@@ -38,7 +38,7 @@
                             <constraint firstItem="egO-IS-oa8" firstAttribute="leading" secondItem="mo8-EK-DS1" secondAttribute="leading" id="GXe-gS-9L5"/>
                             <constraint firstItem="j3W-b1-aMI" firstAttribute="top" secondItem="egO-IS-oa8" secondAttribute="bottom" id="XXx-KW-So4"/>
                             <constraint firstItem="j3W-b1-aMI" firstAttribute="leading" secondItem="mo8-EK-DS1" secondAttribute="leading" id="bpm-T6-axO"/>
-                            <constraint firstItem="egO-IS-oa8" firstAttribute="top" secondItem="mo8-EK-DS1" secondAttribute="top" constant="8" id="qN7-UG-1HQ"/>
+                            <constraint firstItem="egO-IS-oa8" firstAttribute="top" secondItem="mo8-EK-DS1" secondAttribute="top" id="qN7-UG-1HQ"/>
                             <constraint firstItem="mo8-EK-DS1" firstAttribute="trailing" secondItem="j3W-b1-aMI" secondAttribute="trailing" id="qQC-f2-bA9"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="mo8-EK-DS1"/>
@@ -66,7 +66,7 @@
             <objects>
                 <tableViewController id="Kom-qy-mum" customClass="TrackOverviewTableViewController" customModule="GeoTrackKitExample" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="G5G-Aw-OMU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="195"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="203"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>


### PR DESCRIPTION
### Background
Updated the "Share" so that it pops up a list of options and supports the following:
- (Preexisting) JSON export
- Xcode GPX format

### Features Implemented
- [x] Xcode GPX format

### TODO
- [x] Refactor this code into the GeoTrackKit library (it currently lives in the Example Project)

### Checklist
- [x] Appropriate label has been added to this PR (i.e., Bug, Feature, Under Construction, etc.).
- [x] Documentation has been added to all `open`, `public`, and `internal` scoped methods and properties.
- [x] Deferred - this is a trivial feature: ~Tests have have been added to all new features.~
- [x] Image/GIFs have been added for all UI related changed.

### Screenshots

![gpx_sharing](https://user-images.githubusercontent.com/2284832/51073617-ebb10900-1630-11e9-9fba-181507a60fbe.gif)
