### PR TITLE
Example App: Sharing the Geo JSON file

### DIFF
--- a/GeoTrackKitExample/GeoTrackKitExample/Info.plist
+++ b/GeoTrackKitExample/GeoTrackKitExample/Info.plist
@@ -2,6 +2,45 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.icolasoft.GeoTrackKit.track.file</string>
+			</array>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string></string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Track File</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeDescription</key>
+			<string>GeoTrackKit Track File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeIdentifier</key>
+			<string>com.icolasoft.GeoTrackKit.track.file</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<string>gtj</string>
+				<key>public.mime-type</key>
+				<string>application/geotrack-json</string>
+			</dict>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackMapViewController.swift
+++ b/GeoTrackKitExample/GeoTrackKitExample/Views/ReferenceTrack/TrackMapViewController.swift
@@ -108,7 +108,7 @@ private extension TrackMapViewController {
             }
             let documentsFolder = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
             let fileName = model.track.name.trackNameToFileSystemName
-            let fileUrl = documentsFolder.appendingPathComponent("\(fileName).json")
+            let fileUrl = documentsFolder.appendingPathComponent("\(fileName).gtj")
             do {
                 try jsonString.write(to: fileUrl, atomically: false, encoding: .utf8)
             } catch {
@@ -164,7 +164,7 @@ private extension TrackMapViewController {
         let dialog = UIAlertController(title: "Share", message: "How would you like to share?", preferredStyle: .actionSheet)
 
         dialog.addAction(UIAlertAction(title: "JSON", style: .default) { [weak self] _ in
-            self?.shareJsonFile()
+            self?.shareGeoTrackJsonFile()
             dialog.dismiss(animated: true)
         })
         dialog.addAction(UIAlertAction(title: "GPX", style: .default) { [weak self] _ in
@@ -185,8 +185,8 @@ private extension TrackMapViewController {
         present(activityVC, animated: true, completion: nil)
     }
 
-    /// Shares the track as a JSON file
-    func shareJsonFile() {
+    /// Shares the track as a GeoTrack-JSON file
+    func shareGeoTrackJsonFile() {
         guard let trackWrittenToJsonFile = trackWrittenToJsonFile else {
             return
         }

--- a/GeoTrackKitExample/GeoTrackKitExample/Views/TrackList/TrackListTableViewController.swift
+++ b/GeoTrackKitExample/GeoTrackKitExample/Views/TrackList/TrackListTableViewController.swift
@@ -57,6 +57,11 @@ class TrackListTableViewController: UITableViewController {
         guard let track = load(trackUrl: tracks[indexPath.row]) else {
             return
         }
+        if track.track.name.isEmpty {
+            track.track.name = tracks[indexPath.row].filenameNoExtension ?? ""
+        }
+
+
         // swiftlint:disable:next force_cast
         let mapVC = UIStoryboard(name: "TrackView", bundle: nil).instantiateViewController(withIdentifier: "TrackMapViewController") as! TrackMapViewController
         mapVC.useDemoTrack = false


### PR DESCRIPTION
### Background
Exporting JSON wasn't very useful (the filename seemed to always be: `.json`) and I couldn't get other apps to open the file.  So I did some research and added some fixes.

### Features Implemented
- [x] New JSON file type can be exported: `.gtj`

### Notes
- A shout out to Ray Wenderlich's tutorial on [UIActivityViewController - sharing data](https://www.raywenderlich.com/1018-uiactivityviewcontroller-tutorial-sharing-data)

### Checklist

- [x] Appropriate label has been added to this PR (i.e., Bug, Feature, Under Construction, etc.).
- [ ] N/A ~Documentation has been added to all `open`, `public`, and `internal` scoped methods and properties.~
- [ ] Deferred ~Tests have have been added to all new features.~
- [ ] N/A ~Image/GIFs have been added for all UI related changed.~

